### PR TITLE
Skip VGM command 0x7n instead of failing

### DIFF
--- a/tools/src/vgm2psg.c
+++ b/tools/src/vgm2psg.c
@@ -17,6 +17,7 @@
 #define     VGM_FMFOLLOWS   0x51
 #define     VGM_FRAMESKIP_NTSC   0x62
 #define     VGM_FRAMESKIP_PAL    0x63
+#define     VGM_SAMPLESKIP_7N    0x70 // 0x7n  skip n+1 samples
 #define     VGM_SAMPLESKIP  0x61
 #define     VGM_ENDOFDATA   0x66
 
@@ -421,6 +422,14 @@ int main (int argc, char *argv[]) {
         break;
 
       default:
+        // Drop compact (1 to 16) sample skip command
+        if ((c & 0xf0) == VGM_SAMPLESKIP_7N) {
+          printf("Warning: pause length isn't perfectly frame sync'd\n");
+          decLoopOffset(1);
+          if (checkLoopOffset()) writeLoopMarker();
+          break;
+        }
+
         printf("Fatal: found unknown char 0x%02x\n",c);
         leave=1;
         fatal=1;


### PR DESCRIPTION
I came across VGM files which use command 0x7n to skip a small number of samples, but vgm2psg does not support this command and emits an error.

From the VGM spec:
0x7n 		wait n+1 samples, n can range from 0 to 15. 

This is equivalent to passing a value of 1-16 to sample skip command 0x61, which vgm2psg already supports.

When the value is not frame-aligned, vgm2psg does rounding and emits a warning instead of failing.
This patch does the same for command 0x7n, however since skipping 1-16 samples would always result in a frame skip of zero, this patch takes the shortcut of simply ignoring the command.

For reference, the files have this extra 9 sample wait after every 1/60 wait for some reason.

```
0x00000153: 62          Wait:   735 samples (1/60 s)    (total  2223 (00:00.05))
0x00000154: 78          Wait:    9 sample(s) (   0.20 ms)   (total  2232 (00:00.05))  <<<< not supported
```

The cause is probably that the frame rate is incorrect in the tooling used to create the VGM (59.28 Hz instead of 60Hz!?) but I am not the composer and investigating the root cause (if I ever get to it) would take time. But the difference in play speed is minimal, and vgm2psg already tolerates non-aligned delays, so I thought why not also add support for this command? 

While it's not a perfect solution, at least music is playing in my game :-)
