### PR TITLE
Add a reimplementation of psgcomp

### DIFF
--- a/tools/src/Makefile
+++ b/tools/src/Makefile
@@ -1,7 +1,14 @@
+LD=$(CC)
 CFLAGS=-Wall -O3
 LDLIBS=-lz
 
-all: psgcomp psgdecomp vgm2psg
+all: psgcomp psgdecomp vgm2psg psgcomp_ng psg2txt
 
-clean: psgcomp psgdecomp vgm2psg
-	rm -f $^
+psgcomp_ng: psgcomp_ng.o psgcompress.o growbuf.o
+	$(LD) $(LDFLAGS) -o $@ $^
+
+psg2txt: psg2txt.o growbuf.o
+	$(LD) $(LDFLAGS) -o $@ $^
+
+clean: psgcomp psgdecomp vgm2psg psgcomp_ng
+	rm -f $^ *.o

--- a/tools/src/growbuf.c
+++ b/tools/src/growbuf.c
@@ -1,0 +1,148 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include "growbuf.h"
+
+void growbuf_clear(struct growbuf *gb)
+{
+	gb->count = 0;
+}
+
+void growbuf_free(struct growbuf *gb)
+{
+	if (gb) {
+		if (gb->data) {
+			free(gb->data);
+		}
+		free(gb);
+	}
+}
+
+struct growbuf *growbuf_alloc(int initial_size)
+{
+	struct growbuf *gb;
+
+	gb = calloc(1, sizeof(struct growbuf));
+	if (!gb) {
+		perror("growbuf");
+		return NULL;
+	}
+
+	gb->data = calloc(1, initial_size);
+	if (!gb->data) {
+		perror("could not allocate growbuf initial");
+		free(gb);
+		return NULL;
+	}
+
+	gb->alloc_size = initial_size;
+
+	return gb;
+}
+
+void growbuf_append(struct growbuf *gb, const uint8_t *data, int size)
+{
+	uint8_t *d;
+	int newsize;
+
+	if (size <= 0)
+		return;
+
+	if (gb->count + size > gb->alloc_size) {
+		newsize = gb->alloc_size * 2 + size;
+		d = realloc(gb->data, newsize);
+		if (!d) {
+			perror("Could not grow buffer");
+			return;
+		}
+		gb->data = d;
+		gb->alloc_size = newsize;
+	}
+
+	memcpy(gb->data + gb->count, data, size);
+	gb->count += size;
+}
+
+void growbuf_add32le(struct growbuf *gb, uint32_t val)
+{
+	uint8_t tmp[4] = { val, val >> 8, val >> 16, val >> 24 };
+	growbuf_append(gb, tmp, 4);
+}
+
+void growbuf_add16le(struct growbuf *gb, uint16_t val)
+{
+	uint8_t tmp[2] = { val, val >> 8 };
+	growbuf_append(gb, tmp, 2);
+}
+
+void growbuf_add8(struct growbuf *gb, uint8_t val)
+{
+	uint8_t tmp[2] = { val };
+	growbuf_append(gb, tmp, 1);
+}
+
+int growbuf_writeToFPTR(const struct growbuf *gb, FILE *fptr)
+{
+	return fwrite(gb->data, gb->count, 1, fptr);
+}
+
+int growbuf_saveToFile(const struct growbuf *gb, const char *filename)
+{
+	FILE *fptr;
+
+	fptr = fopen(filename, "wb");
+	if (!fptr) {
+		perror(filename);
+		return -1;
+	}
+
+	growbuf_writeToFPTR(gb, fptr);
+
+	fclose(fptr);
+
+	return 0;
+}
+
+struct growbuf *growbuf_createFromFile(const char *filename)
+{
+	FILE *fptr;
+	long filesize;
+	struct growbuf *gb;
+
+	fptr = fopen(filename, "rb");
+	if (!fptr) {
+		perror(filename);
+		return NULL;
+	}
+
+	fseek(fptr, 0, SEEK_END);
+	filesize = ftell(fptr);
+	fseek(fptr, 0, SEEK_SET);
+
+	if (filesize > INT_MAX) {
+		fprintf(stderr, "File too large\n");
+		return NULL;
+	}
+
+	gb = growbuf_alloc(filesize);
+	if (!gb) {
+		fprintf(stderr, "could not load %s\n", filename);
+		fclose(fptr);
+		return NULL;
+	}
+
+	if (1 != fread(gb->data, filesize, 1, fptr)) {
+		perror(filename);
+		fclose(fptr);
+		growbuf_free(gb);
+		return NULL;
+	}
+	gb->count = filesize;
+
+	fclose(fptr);
+
+	return gb;
+}
+
+

--- a/tools/src/growbuf.h
+++ b/tools/src/growbuf.h
@@ -1,0 +1,35 @@
+#ifndef _growbuf_h__
+#define _growbuf_h__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+#include <stdint.h>
+
+struct growbuf {
+	int count;
+
+	uint8_t *data;
+	int alloc_size;
+};
+
+void growbuf_free(struct growbuf *gb);
+struct growbuf *growbuf_alloc(int initial_size);
+struct growbuf *growbuf_createFromFile(const char *filename);
+void growbuf_append(struct growbuf *gb, const uint8_t *data, int size);
+void growbuf_clear(struct growbuf *gb);
+
+void growbuf_add32le(struct growbuf *gb, uint32_t val);
+void growbuf_add16le(struct growbuf *gb, uint16_t val);
+void growbuf_add8(struct growbuf *gb, uint8_t val);
+
+int growbuf_saveToFile(const struct growbuf *gb, const char *filename);
+int growbuf_writeToFPTR(const struct growbuf *gb, FILE *fptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _growbuf_h__

--- a/tools/src/psg2txt.c
+++ b/tools/src/psg2txt.c
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
 			frameno += 1 + (op & 0x7);
 
 			if (!terse_output) {
-				printf("Wait %d frames\n", op & 0x7);
+				printf("End of frame, wait %d additional frames\n", op & 0x7);
 			}
 			continue;
 		}

--- a/tools/src/psg2txt.c
+++ b/tools/src/psg2txt.c
@@ -1,0 +1,207 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <getopt.h>
+#include "growbuf.h"
+
+static void printUsage(void)
+{
+	printf("Usage: ./psg2txt [options] input.psg\n");
+	printf("\n");
+	printf("Supported options:\n");
+	printf(" -h          Display this usage information\n");
+	printf(" -t          Terse output (summary only)\n");
+	printf("\n");
+}
+
+int main(int argc, char **argv)
+{
+	uint8_t op;
+	int op_offset;
+	uint8_t chn, type, data;
+	int frameno;
+	struct growbuf *psg;
+	int pos;
+	uint8_t tmp[2];
+	int loopoffset = 0;
+	int loopset_count = 0;
+	const char *in_filename;
+	int compressed = 0;
+	int end_offset = -1;
+	int block_offset, block_length;
+	int opt;
+	int terse_output = 0;
+
+	while ((opt = getopt(argc, argv, "ht")) != -1) {
+		switch (opt)
+		{
+			case 'h':
+				printUsage();
+				return 0;
+				break;
+
+			case 't':
+				terse_output = 1;
+				break;
+
+			case '?':
+				fprintf(stderr, "Unsupported option. Try -h\n");
+				return -1;
+		}
+	}
+
+	if (optind >= argc) {
+		fprintf(stderr, "Missing arguments(s). Try -h\n");
+		return -1;
+	}
+
+	in_filename = argv[optind];
+
+	psg = growbuf_createFromFile(in_filename);
+	if (!psg) {
+		return -1;
+	}
+
+	printf("* * * psg2txt by raphnet\n");
+	printf("Examining %s...\n", in_filename);
+
+	frameno = 0;
+	pos = 0;
+
+	while (pos < psg->count)
+	{
+		// Store offset of new operation
+		op_offset = pos;
+
+		// Store operation, advance position
+		op = psg->data[pos];
+		pos++;
+
+		if (op >= 0x08 && op <= 0x37) {
+			// special case for compression (3 bytes)
+			if (pos+2 > psg->count) {
+				printf("Error: truncated compression command at end of data\n");
+				break;
+			}
+			memcpy(tmp, &psg->data[pos], 2);
+			if (!terse_output) {
+				printf("[%04x] %02x %02x %02x : Frame %05d : ", op_offset, op, tmp[0], tmp[1], frameno);
+			}
+		}
+		else {
+			// Normal case (1 bytes)
+			if (!terse_output) {
+				printf("[%04x] %02x       : Frame %05d : ", op_offset, op, frameno);
+			}
+		}
+
+		// %1cct xxxx = Latch/Data byte for SN76489 channel c, type t, data xxxx (4 bits)
+		if (op & 0x80) {
+			chn = (op >> 5) & 3;
+			type = (op >> 4) & 1;
+			data = op & 0xf;
+
+			if (terse_output) {
+				continue;
+			}
+
+			if (type == 1) {
+				printf("Channel %d, attenuation=0x%x\n", chn, data);
+			} else {
+				printf("Channel %d, latch data=0x%x\n", chn, data);
+			}
+			continue;
+		}
+
+		// %01xx xxxx = Data byte for SN76489 latched channel and type, data xxxxxx (6 bits)
+		if (op & 0x40) {
+			data = op & 0x3f;
+			if (!terse_output) {
+				printf("data=0x%02x\n", data);
+			}
+			// todo: track latched channel and data, show full value here?
+			continue;
+		}
+
+		// %0011 1nnn - end of frame, wait nnn additional frames (0-7)
+		if (op >= 0x38) {
+			frameno += 1 + (op & 0x7);
+
+			if (!terse_output) {
+				printf("Wait %d frames\n", op & 0x7);
+			}
+			continue;
+		}
+
+		if (op == 0x01) {
+			if (!terse_output) {
+				printf("Loop marker (offset 0x%04x)\n", op_offset);
+			}
+			loopset_count++;
+			loopoffset = op_offset;
+			continue;
+		}
+		if (op == 0) { // End of data
+			if (!terse_output) {
+				printf("End of data\n");
+			}
+			end_offset = op_offset;
+			break;
+		}
+		if (op < 7) {
+			printf("Error: Unknown command 0x%02x\n", op);
+			break;
+		}
+
+		// Compression (values 0x08-0x37)
+		compressed = 1;
+		if (pos+2 > psg->count) {
+			fprintf(stderr, "Error: truncated compression command at end of data\n");
+			break;
+		}
+		memcpy(tmp, &psg->data[pos], 2);
+		pos+=2;
+		block_offset = tmp[0] | (tmp[1]<<8);
+		block_length = op - 0x08 + 4;
+
+		if (!terse_output) {
+			printf("Repeat block[%d] at 0x%04x\n", block_length, block_offset);
+		}
+
+		// detect invalid out-of-range blocks
+		if ((block_offset + block_length) > op_offset) {
+			fprintf(stderr, "Error: Compressed block goes past current position\n");
+			break;
+		}
+	}
+
+	if (pos != psg->count) {
+		growbuf_free(psg);
+		return -1;
+	}
+
+	printf("--- Summary ---\n");
+	printf("Size: %d\n", psg->count);
+	printf("Frames: %d\n", frameno);
+	printf("Compressed PSG: %s\n", compressed ? "Yes":"No");
+	if (loopset_count == 0) {
+		printf("No loop point\n");
+	} else {
+		printf("Looppoint: 0x%04x (%d)\n", loopoffset, loopoffset);
+	}
+	if (loopoffset > 1) {
+		printf("Warning: Loop point set more than once\n");
+	}
+	if (end_offset == -1) {
+		printf("Warning: No end command\n");
+	} else {
+		printf("End offset: 0x%04x (%d)\n", end_offset, end_offset);
+	}
+	if (end_offset+1 != psg->count) {
+		printf("Warning: Extra data after end of data marker.\n");
+	}
+
+	growbuf_free(psg);
+	return 0;
+}
+

--- a/tools/src/psgcomp_ng.c
+++ b/tools/src/psgcomp_ng.c
@@ -1,0 +1,92 @@
+#include <stdio.h>
+#include <string.h>
+#include <getopt.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include "psgcompress.h"
+
+int g_verbose = 0;
+
+static void printUsage(void)
+{
+	printf("Usage: ./psgcomp_ng [options] inputfile.psg output.psgcomp\n");
+	printf("\n");
+	printf("Supported options:\n");
+	printf(" -h          Display this usage information\n");
+	printf(" -v          Verbose output\n");
+	printf("\n");
+}
+
+int main(int argc, char **argv)
+{
+	struct growbuf *gb = NULL;
+	struct growbuf *gb_compressed = NULL;
+	const char *in_filename = NULL;
+	const char *out_filename = NULL;
+	int exit_value = -1;
+	int opt;
+
+	while ((opt = getopt(argc, argv, "hcvi:")) != -1) {
+		switch (opt)
+		{
+			case 'h':
+				printUsage();
+				return 0;
+				break;
+
+			case 'v':
+				g_verbose = 1;
+				break;
+		}
+	}
+
+	if (optind >= argc-1) {
+		fprintf(stderr, "Missing arguments(s). Try -h\n");
+		return -1;
+	}
+
+	in_filename = argv[optind];
+	out_filename = argv[optind+1];
+
+	if (g_verbose) {
+		printf(" * * * raphnet's vgmcomp_ng\n");
+		printf("Input file: %s\n", in_filename);
+		printf("Output file: %s\n", out_filename);
+	}
+
+	gb = growbuf_createFromFile(in_filename);
+	if (!gb) {
+		fprintf(stderr, "Could not load %s\n", in_filename);
+		goto error;
+	}
+
+	if (g_verbose) {
+		printf("Loaded PSG data size: %d\n", gb->count);
+		printf("Compressing...\n");
+	}
+
+	gb_compressed = compressPSG(gb, 1);
+	if (!gb_compressed) {
+		fprintf(stderr, "Compression failed\n");
+		goto error;
+	}
+
+	if (g_verbose) {
+		printf("Compressed PSG size: %d\n", gb_compressed->count);
+	}
+
+
+	growbuf_saveToFile(gb_compressed, out_filename);
+	exit_value = 0;
+
+error:
+	if (gb) {
+		growbuf_free(gb);
+	}
+	if (gb_compressed) {
+		growbuf_free(gb_compressed);
+	}
+
+	return exit_value;
+}
+

--- a/tools/src/psgcompress.c
+++ b/tools/src/psgcompress.c
@@ -1,0 +1,151 @@
+#include <stdio.h>
+#include <string.h>
+#include "growbuf.h"
+
+#define COMPRESSION_MAXLEN	51
+#define MIN_COMPRESSION		4
+#define PSG_LOOPMARKER  0x01
+
+extern int g_verbose;
+
+static int searchPastString(const unsigned char *past, int past_length, const unsigned char *data, int maxlen, int min_length, int *matchOffset)
+{
+	int testlength;
+	int startoffset;
+	int bestlength=0;
+	int bestoffset=0;
+	int matchesFound=0;
+
+	// Try all supported compressed block length, 4 to 51 (or less, if past_length or maxlen are small)
+	for (testlength = min_length; testlength < COMPRESSION_MAXLEN && testlength < past_length && testlength < maxlen; testlength++)
+	{
+		if (memchr(data, PSG_LOOPMARKER, testlength)) {
+			// if testlength now encompasses the loop marker, stop here, since the loop marker cannot be
+			// in a compressed block.
+			break;
+		}
+
+		// Now check if the past data contains a sequence identical to the first 'testlength' bytes of 'data'
+		matchesFound = 0;
+		for (startoffset = 0; ((startoffset + testlength) < past_length); startoffset++) {
+			if (memcmp(past + startoffset, data, testlength) == 0) {
+				bestlength = testlength;
+				bestoffset = startoffset;
+				matchesFound = 1;
+				// Since testlength is always increasing, the match here is always the best so far,
+				// and as further matches in this inner loop would also be of "testlength" length (i.e. never longer),
+				// we can break out from the loop. (length then increases in the outer loop)
+				break;
+			}
+		}
+
+		// If no match is found for a given length, there cannot be a match for a longer lengths, so stop here.
+		if (!matchesFound) {
+			break;
+		}
+	}
+
+	if (matchOffset) {
+		*matchOffset = bestoffset;
+	}
+
+	return bestlength;
+}
+
+static struct growbuf *compressPSG_min(struct growbuf *gb, int minimum_substring_length)
+{
+	struct growbuf *gb_out;
+	int pos;
+	int length;
+	int matchoffset;
+	unsigned char tmp[3];
+
+	if (minimum_substring_length < MIN_COMPRESSION)
+		return NULL;
+
+	gb_out = growbuf_alloc(gb->count);
+	if (!gb_out)
+		return NULL;
+
+	for (pos=0; pos<gb->count; pos++) {
+		if (pos < MIN_COMPRESSION) {
+			growbuf_append(gb_out, &gb->data[pos], 1);
+			continue;
+		}
+
+		// Check how many bytes starting at the current position
+		// match something that was already output.
+		length = searchPastString(gb_out->data, gb_out->count,
+									&gb->data[pos], gb->count - pos,
+									minimum_substring_length,
+									&matchoffset
+							);
+
+		if (length > COMPRESSION_MAXLEN) {
+			fprintf(stderr, "internal error\n");
+			growbuf_free(gb_out);
+			return NULL;
+		}
+
+		if (length < minimum_substring_length) {
+			// not worth compressing (would result in equal or larger file size)
+			growbuf_append(gb_out, &gb->data[pos], 1);
+		}
+		else {
+			tmp[0] = 0x08 + length - MIN_COMPRESSION;
+			tmp[1] = matchoffset & 0xff;
+			tmp[2] = (matchoffset >> 8) & 0xff;
+			growbuf_append(gb_out, tmp, 3);
+			pos += length-1; // skip additional bytes "consumed" by compression
+		}
+	}
+
+	return gb_out;
+}
+
+struct growbuf *compressPSG(struct growbuf *gb, int agressive)
+{
+	int i;
+	int best_result = -1;
+	struct growbuf *attempt;
+	struct growbuf *best = NULL;
+
+	if (!agressive) {
+		// According to my testing, the sweet spot is around 8
+		return compressPSG(gb, 8);
+	}
+
+	if (g_verbose) {
+		printf("Looking for best compression...\n");
+	}
+
+
+	for (i=MIN_COMPRESSION; i<COMPRESSION_MAXLEN; i++) {
+		attempt = compressPSG_min(gb, i);
+		if (!attempt) {
+			fprintf(stderr, "out of memory\n");
+			return NULL;
+		}
+
+		if (g_verbose) {
+			printf("%d , %d\n", i, attempt->count);
+		}
+
+		if (best == NULL || attempt->count < best_result) {
+			best = attempt;
+			best_result = attempt->count;
+			attempt = NULL;
+		} else {
+			if (g_verbose) {
+				printf("Size started going up - stopping here\n");
+			}
+			break;
+		}
+		if (attempt) {
+			growbuf_free(attempt);
+		}
+	}
+
+	return best;
+}
+

--- a/tools/src/psgcompress.h
+++ b/tools/src/psgcompress.h
@@ -1,0 +1,9 @@
+#ifndef _psgcompress_h__
+#define _psgcompress_h__
+
+#include "growbuf.h"
+
+struct growbuf *compressPSG(struct growbuf *gb, int agressive);
+
+#endif // _psgcompress_h__
+


### PR DESCRIPTION
This patch adds my reimplementation of psgcomp (under the name psgcomp_ng) which improves compression as discussed in issue #6 

The command-line interface is compatible with the original, but the output is silent by default. (add -v to see the search for the best compression)
```
Usage: ./psgcomp_ng [options] inputfile.psg output.psgcomp

Supported options:
 -h          Display this usage information
 -v          Verbose output
```

I also added psg2txt which converts a PSG to a human readable format, like vgm2txt does, which I find very useful when I need to see exactly what's going on:

```
[3ed1] 8e       : Frame 02098 : Channel 0, latch data=0xe
[3ed2] 4c       : Frame 02098 : data=0x0c
[3ed3] b6       : Frame 02098 : Channel 1, attenuation=0x6
[3ed4] c1       : Frame 02098 : Channel 2, latch data=0x1
[3ed5] 78       : Frame 02098 : data=0x38
[3ed6] d2       : Frame 02098 : Channel 2, attenuation=0x2
[3ed7] e0       : Frame 02098 : Channel 3, latch data=0x0
[3ed8] 38       : Frame 02098 : Wait 0 frames
[3ed9] 8a       : Frame 02099 : Channel 0, latch data=0xa
[3eda] 36 68 32 : Frame 02099 : Repeat block[50] at 0x3268
```

There is also a summary at the end, and the -t command-line option is available to show only the summary.
```
--- Summary ---
Size: 18280
Frames: 2393
Compressed PSG: Yes
Looppoint: 0x0913 (2323)
Warning: Loop point set more than once
End offset: 0x4767 (18279)
```
